### PR TITLE
Remove borders and excess padding from widgets that use menus

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -788,6 +788,7 @@ footer .footerHeader {
 
 .widget .button {
 	padding: 1em 0;
+	max-width: none;
 }
 
 .page-template-default .widget ul.menu {

--- a/css/style.css
+++ b/css/style.css
@@ -790,6 +790,11 @@ footer .footerHeader {
 	padding: 1em 0;
 }
 
+.page-template-default .widget ul.menu {
+	border: none;
+	padding: 0;
+}
+
 /* ---- Widgets ---- */
 .staff-widget {
 	float: left;

--- a/css/style.css
+++ b/css/style.css
@@ -788,7 +788,6 @@ footer .footerHeader {
 
 .widget .button {
 	padding: 1em 0;
-	max-width: none;
 }
 
 .page-template-default .widget ul.menu {


### PR DESCRIPTION
Tagging @frrrances for code review: Removes border and excess padding. Resolves #24.
