### PR TITLE
Adds another closing parenthesis; fixes #63

### DIFF
--- a/inc/postHead.php
+++ b/inc/postHead.php
@@ -5,9 +5,10 @@
 						<h1 class="child-page-title"><?php bloginfo(); ?></h1>
 						<?php
 						// Checks to see if tagline exists.
-						if ( ! empty( get_bloginfo( 'description' ) ) ) :
+						$description = get_bloginfo( 'description' );
+						if ( ! empty( $description ) ) :
 							?> 
-						<p class="child-tagline"><?php bloginfo( 'description' ); ?></p>
+						<p class="child-tagline"><?php echo esc_html( $description ); ?></p>
 						<?php endif; ?>
 						
 						<?php

--- a/inc/postHead.php
+++ b/inc/postHead.php
@@ -4,8 +4,8 @@
 				<div class="page-header-home">
 						<h1 class="child-page-title"><?php bloginfo(); ?></h1>
 						<?php
-							// Checks to see if tagline exists
-							if( !empty( get_bloginfo('description') ) : 
+						// Checks to see if tagline exists.
+						if ( ! empty( get_bloginfo( 'description' ) ) ) :
 							?> 
 						<p class="child-tagline"><?php bloginfo( 'description' ); ?></p>
 						<?php endif; ?>


### PR DESCRIPTION
Tagging @frrrances for code review.

This solves a somewhat thorny problem in inc/postHead.php, which had two syntax errors on line 8. 

The first was mis-matched parentheses, and was relatively easy to resolve.

The second was that the `empty()` function cannot be called on the results of a function, but only on a pre-defined variable. So, this PR first calls `get_bloginfo()` and stores the result in a temporary variable, and then applies `empty()` on _that_.

The message from the syntax checker, for the record, was:

```
PHP Fatal error:  Can't use function return value in write context in ./inc/postHead.php on line 8
Fatal error: Can't use function return value in write context in ./inc/postHead.php on line 8
Errors parsing ./inc/postHead.php
```

Looking at the documentation for `empty()` at http://php.net/manual/en/function.empty.php there's a note:

```
*Note:* Because this is a language construct and not a function, it cannot be called using variable functions.
```
