### PR TITLE
Fix styling of .wrap-section-hilite on screens < 380px

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1398,17 +1398,10 @@ a.exhibits-button:focus {
 	}
 	
 	/* ---- Sticky/Post Excerpts + Flexbox Layout---- */
-	.wrap-section-hilite {
-		flex-direction: column;
-	}
-
 	.section-hilite-image {
-		margin: 0 auto;
-		margin-bottom: 25px;
-	}
-
-	.section-hilite {
-		text-align: center;
+		top: 25px;
+		width: 75%;
+		height: 75%;
 	}
 
 	/* ---- Exhibits Styles ---- */


### PR DESCRIPTION
Tagging @frrrances for code-review: Fixes styling by removing centered text, broken image. Resolves #71.
