### PR TITLE
Gallery has no margins between items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,6 +415,13 @@ figcaption {
 	margin: 4px 8px;
 }
 
+dl.gallery-item {
+	float: left;
+    margin: 1%;
+    text-align: center;
+    width: 31%;
+}
+
 dt.gallery-icon,
 dd.wp-caption-text {
 	background: #efefef;

--- a/functions.php
+++ b/functions.php
@@ -308,3 +308,8 @@ function get_first_post_image() {
 	}
 	return $first_img;
 }
+
+/**
+ * Remove native Gallery styling
+ */
+add_filter( 'use_default_gallery_style', '__return_false' );


### PR DESCRIPTION
Tagging @frrrances or @matt-bernhardt for code-review: when using native WordPress image gallery, a native set of styling is generated which is difficult to overwrite unless targeting a specific gallery, (i.e. #gallery-1, #gallery-2, #gallery-3, etc...) which is obviously, sub-optimal, so... adding a function to remove native-styling and then adding a rule to replace what controls each gallery-item and its margins, etc. Resolves #90.
