### PR TITLE
Add child stylesheet with dependency upon parent; closes #102

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,10 +29,15 @@ add_action( 'wp_enqueue_scripts', 'enqueue_my_scripts' );
 
 /**
  * Add theme-specific stylesheets
+ *
+ * @link http://mor10.com/challenges-new-method-inheriting-parent-styles-wordpress-child-themes/
  */
 function enqueue_my_styles() {
+	// First we enqueue style libraries.
 	wp_enqueue_style( 'bootstrap', '//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css' );
 	wp_enqueue_style( 'font-awesome', '//maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css' );
+	// Then enqueues the child stylesheet with a dependency on the parent style, which _should_ enforce correct load order.
+	wp_enqueue_style( 'child-style', get_stylesheet_uri(), array( 'libraries-global' ) );
 }
 add_action( 'wp_enqueue_scripts', 'enqueue_my_styles' );
 


### PR DESCRIPTION
Tagging @frrrances for code review. This formally adds the child stylesheet with a dependency on the parent stylesheet.

This still runs into the issue described in http://mor10.com/challenges-new-method-inheriting-parent-styles-wordpress-child-themes/ where the parent theme has many stylesheets, and right now we're only bringing in one. However, this branch doesn't _introduce_ that problem, we already have it. Also, the parent theme is structured so that all the styles that need to inherit downwards are in the one imported stylesheet already.
