### PR TITLE
Exhibits fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -454,41 +454,17 @@ dd.wp-caption-text {
 }
 
 /* ---- Full Width Template Styles ---- */
-.section-wrapper {
-	padding-bottom: 50px;
-	margin-bottom: 50px;
-	border-bottom: 1px solid #888;
-	float: left;
-}
 
-.section-wrapper-last {
-	float: left;
-	margin: 25px 0;
-}
-
-.main {
+/* banded page with columns in bands */
+.section-wrapper .main {
 	float: left;
 	padding-right: 2em;
 	width: 76%;
 }
 
-.main p {
-	margin-bottom: 1.25em ;
-	line-height: 1.5;
-}
-
-.main h3 {
-	font-size: 1.5em;
-	font-weight: 700;
-	padding: 1em 0;
-}
-
-.location-hours {
-	font-weight: 700;
-}
-
-.contact-email {
-	font-weight: bold;
+.section-wrapper .sidebar {
+	float: left;
+	width: 23.91%;
 }
 
 .box {
@@ -532,12 +508,14 @@ dd.wp-caption-text {
 }
 
 .entry-content h1,
-.meta-header {
-	line-height:1;
-	text-transform: uppercase;
+.meta-header, 
+.title-sub {
+	margin-bottom: 15px;
 	font-size: 14px;
+	font-weight: 400;
+	line-height: 1.3;
 	color: #777;
-	margin-bottom: 10px;
+	text-transform: uppercase;
 }
 
 .entry-content h2 {
@@ -1017,20 +995,12 @@ a.px14 {
 	line-height: 1.5;
 }
 
-h4 a.exhibit-title {
+.exhibit-title {
 	padding-bottom: 0;
 	font-size: 18px;
 	color: #333;
 	font-weight: 600;
 	line-height: 1.5;
-}
-
-h3.exhibits {
-	font-size: 16px;
-	font-weight: 400;
-	text-transform: uppercase;
-	line-height: 3;
-	color: #777;
 }
 
 .exhibits-feed-section {
@@ -1047,6 +1017,7 @@ h3.exhibits {
 	left: 215px;
 	text-transform: uppercase;
 	font-size: 13px;
+	font-weight: 600;
 }
 
 .date-span {
@@ -1060,29 +1031,30 @@ h3.exhibits {
 .sponsored-excerpt {
 	background: #cbcbcb;
 	padding: 10px 15px;
-	-webkit-box-shadow: inset 0px 10px 10px -5px rgba(0,0,0,.4);
-    box-shadow: inset 0px 10px 10px -5px rgba(0,0,0,.4);
-    margin: 10px 0 0 27.5px;
+  box-shadow: inset 0px 10px 10px -5px rgba(0,0,0,.4);
+  margin: 10px 0 0 27.5px;
 	font-size: 13px;
 	font-weight: 600;
 }
 
-a.exhibits-button {
-	width: 100%;
+.exhibits-button {
+	display: block;
 	text-align: right;
 }
 
-a.exhibits-button:after {
+.exhibits-button:after {
 	content:'\f061';
 	display:inline-block;
 	font-family:'fontawesome';
 	margin-left:.5em;
 }
 
-a.exhibits-button:hover,
-a.exhibits-button:focus {
+.exhibits-button:hover,
+.exhibits-button:focus {
 	background-color: #338bc5;
 	border-color: #338bc5;
+	color: #fff;
+	text-decoration: none;
 }
 
 /* ---- Fields, Inputs, Buttons etc. ---- */
@@ -1276,19 +1248,13 @@ a.exhibits-button:focus {
 	}
 	
 	.section-wrapper .main,
-	.section-wrapper .sidebar,
-	.section-wrapper-last .main,
-	.section-wrapper-last .sidebar {
+	.section-wrapper .sidebar {
 		width: 100%;
 	}
 
-	.section-wrapper .sidebar,
-	.section-wrapper-last .sidebar {
-		margin-top: 50px;
-	}
-
-	.section-wrapper-last {
-		margin-bottom: 80px;
+	.section-wrapper .sidebar {
+		margin: 10px 0 20px 0;
+		padding: 0;
 	}
 
 	/* ---- Header Styles ---- */
@@ -1337,7 +1303,7 @@ a.exhibits-button:focus {
 	.category-image {
 		height: 200px;
 		min-width: 100% !important;
-		background-position: center top;
+		background-position: center center;
 	}
 
 	.childTheme .exhibits-feed .category-init {
@@ -1366,11 +1332,8 @@ a.exhibits-button:focus {
 	}
 
 	.exhibit-ends {
-		position: absolute;
 		bottom: 10px;
 		left: 15px;
-		text-transform: uppercase;
-		font-size: 13px;
 	}
 
 	.exhibits-feed-section:last-child {

--- a/inc/exhibits-current.php
+++ b/inc/exhibits-current.php
@@ -20,16 +20,16 @@ $todaysDate = date( 'm/d/Y H:i:s' );
 
 			<div class="exhibits-feed">
 				<div class="entry-categories">
-	                <div class="entry-cats-list">
-		                <?php
-						foreach ( (get_the_category()) as $category ) {
-							echo '<a href="/exhibits/about-alternate/">' . '<span class="category-bg"><span class="category-init">' . (substr( $category->cat_name,0,1 ))  . '</span></span>' . '<span class="cat-name">' . $category->cat_name . ' Exhibit' . '</span>' . '</a>';
-						}
-						?>
+					<div class="entry-cats-list">
+
+						<?php foreach ( (get_the_category()) as $category ) { ?>
+							<a href="/exhibits/about/"><span class="category-bg"><span class="category-init"><?php echo esc_attr( substr( $category->cat_name,0,1 ) ); ?></span></span><span class="cat-name"><?php echo esc_attr( $category->cat_name ); ?> Exhibit</span></a>
+						<?php } ?>
+
 					</div>
-              	</div>
+      	</div>
               	
-              	<div class="category-post">
+        <div class="category-post">
 					<div class="category-image" style="background-image: url('<?php get_stylesheet_directory_uri();
 the_field( 'exhibit_thumbnail_image' ); ?>');">
 					</div>
@@ -39,7 +39,7 @@ the_field( 'exhibit_thumbnail_image' ); ?>');">
 			              <p><?php custom_excerpt( 35, '...' ) ?></p>
 						</div>
 						<div class="exhibit-ends">
-							Ends <?php the_field( 'end_date' ); ?>
+						<?php the_field( 'start_date' ); ?> - <?php the_field( 'end_date' ); ?>
 						</div>
 					</div>
             	</div>

--- a/inc/exhibits-past.php
+++ b/inc/exhibits-past.php
@@ -19,12 +19,10 @@ $todaysDate = date( 'm/d/Y H:i:s' );
 
 			<div class="exhibits-feed">
 				<div class="entry-categories">
-	                <div class="entry-cats-list">
-		                <?php
-						foreach ( (get_the_category()) as $category ) {
-							echo '<a href="/exhibits/about-alternate/">' . '<span class="category-bg"><span class="category-init">' . (substr( $category->cat_name,0,1 ))  . '</span></span>' . '<span class="cat-name">' . $category->cat_name . ' Exhibit' . '</span>' . '</a>';
-						}
-						?>
+					<div class="entry-cats-list">
+						<?php foreach ( (get_the_category()) as $category ) { ?>
+							<a href="/exhibits/about/"><span class="category-bg"><span class="category-init"><?php echo esc_attr( substr( $category->cat_name,0,1 ) ); ?></span></span><span class="cat-name"><?php echo esc_attr( $category->cat_name ); ?> Exhibit</span></a>
+						<?php } ?>
 					</div>
               	</div>
               	

--- a/inc/exhibits-upcoming.php
+++ b/inc/exhibits-upcoming.php
@@ -19,34 +19,31 @@ $todaysDate = date( 'm/d/Y H:i:s' );
 
 			<div class="exhibits-feed">
 				<div class="entry-categories">
-	                <div class="entry-cats-list">
-		                <?php
-						foreach ( (get_the_category()) as $category ) {
-							echo '<a href="/exhibits/about-alternate/">' . '<span class="category-bg"><span class="category-init">' . (substr( $category->cat_name,0,1 ))  . '</span></span>' . '<span class="cat-name">' . $category->cat_name . ' Exhibit' . '</span>' . '</a>';
-						}
-						?>
+					<div class="entry-cats-list">
+						<?php foreach ( (get_the_category()) as $category ) { ?>
+							<a href="/exhibits/about/"><span class="category-bg"><span class="category-init"><?php echo esc_attr( substr( $category->cat_name,0,1 ) ); ?></span></span><span class="cat-name"><?php echo esc_attr( $category->cat_name ); ?> Exhibit</span></a>
+						<?php } ?>
 					</div>
-              	</div>
+				</div>
               	
-              	<div class="category-post">
+				<div class="category-post">
 					<div class="category-image" style="background-image: url('<?php get_stylesheet_directory_uri();
 the_field( 'exhibit_thumbnail_image' ); ?>');">
 					</div>
 					<div class="category-post-content">
 						<h4><a class="exhibit-title" href="<?php the_permalink(); ?>"><?php the_title();?></a></h4>
-			            <div class="entry-summary">
-			              <p><?php custom_excerpt( 35, '...' ) ?></p>
+						<div class="entry-summary">
+							<p><?php custom_excerpt( 35, '...' ) ?></p>
 						</div>
 						<div class="exhibit-ends">
-							Starts <?php the_field( 'start_date' ); ?>
+							Opens <?php the_field( 'start_date' ); ?>
 						</div>
 					</div>
-            	</div>
+				</div>
 
-              	<?php if ( get_field( 'sponsored' ) ) : ?>
-	              	<div class="sponsored-excerpt">
+				<?php if ( get_field( 'sponsored' ) ) : ?>
+				<div class="sponsored-excerpt">
 					<?php the_field( 'sponsored' ); ?>
-					</div>
+				</div>
 				<?php endif; ?>
-
 			</div>

--- a/page-exhibits-feed.php
+++ b/page-exhibits-feed.php
@@ -21,16 +21,14 @@ get_header();
 
 		<?php
 
-			$date1 = DateTime::createFromFormat( 'Ymd', get_field( 'start_date','end_date' ) );
-
 			$current_query = new WP_Query(
 				array(
 					'posts_per_page' => -1,
 					'ignore_sticky_posts' => false,
 					'post_type'   => 'exhibits',  // Only query exhibits.
-					'meta_key'    => 'end_date',  // Load up the event_date meta.
-					'order_by'    => 'end_date',
-					'order'       => 'desc',      // Descending, so later events first.
+					'meta_key'    => 'start_date',  // Load up the event_date meta.
+					'orderby'     => 'start_date',
+					'order'       => 'DESC',      // Descending, so later events first.
 					'meta_query'  => array(
 						array(
 							'key'     => 'start_date',     // Which meta to query.
@@ -49,9 +47,9 @@ get_header();
 			); // Close WP_Query constructor call.
 		?> 
         
-        	<div class="exhibits-feed-section">
+			<div class="exhibits-feed-section">
 			
-				<h3 class="exhibits">Current Exhibits</h3>   
+				<h3 class="title-sub">Current Exhibits</h3>
 						 
 				<?php if ( $current_query->have_posts() ) :
 					while ( $current_query->have_posts() ) : $current_query->the_post(); // Loop for current exhibits.
@@ -75,14 +73,12 @@ get_header();
 
 		<?php
 
-			$date2 = DateTime::createFromFormat( 'Ymd', get_field( 'start_date' ) );
-
 		$future_query = new WP_Query(
 	        array(
 	          'post_type'   => 'exhibits',    // Only query exhibits.
 	          'meta_key'    => 'start_date',  // Load up the event_date meta.
-	          'order_by'    => 'start_date',
-	          'order'       => 'desc',        // Descending, so later events first.
+	          'orderby'    => 'start_date',
+	          'order'       => 'ASC',        // Descending, so later events first.
 	          'meta_query'  => array(
 	             array(
 	              'key'     => 'start_date',     // Which meta to query.
@@ -97,12 +93,12 @@ get_header();
 			
 			<div class="exhibits-feed-section">
 				
-				<h3 class="exhibits">Upcoming Exhibits</h3>   
+				<h3 class="title-sub">Upcoming Exhibits</h3>
 				 
 				<?php if ( $future_query->have_posts() ) :
 					while ( $future_query->have_posts() ) : $future_query->the_post(); // Loop for future exhibits.
 
-						get_template_part( 'inc/exhibits-current' );
+						get_template_part( 'inc/exhibits-upcoming' );
 
 					endwhile;
 
@@ -122,14 +118,12 @@ get_header();
 		 
 		<?php
 
-			$date3 = DateTime::createFromFormat( 'Ymd', get_field( 'end_date' ) );
-
 		$past_query = new WP_Query(
 	        array(
 	          'post_type'   => 'exhibits',  // Only query events.
 	          'meta_key'    => 'end_date',  // Load up the event_date meta.
-	          'order_by'    => 'end_date',
-	          'order'       => 'desc',      // Descending, so later events first.
+	          'orderby'    => 'meta_value_num',
+	          'order'       => 'DESC',      // Descending, so later events first.
 	          'meta_query'  => array(
 	             array(
 	              'key'     => 'end_date',       // Which meta to query.
@@ -145,7 +139,7 @@ get_header();
 		
 			<div class="exhibits-feed-section">
 			
-				<h3 class="exhibits">Past Exhibits</h3>   
+				<h3 class="title-sub">Past Exhibits</h3>
 				 
 		   <?php while ( $past_query->have_posts() ) : $past_query->the_post(); // Loop for events.
 

--- a/page-exhibits-home.php
+++ b/page-exhibits-home.php
@@ -27,6 +27,13 @@ $todaysDate = date( 'm/d/Y H:i:s' );
 			<div id="content" class="content has-sidebar">
 
 				<div class="main-content">
+
+					<?php while ( have_posts() ) : the_post();
+
+						the_content();
+						wp_reset_postdata();
+
+					endwhile; ?>
 					
 					<?php
 


### PR DESCRIPTION
This PR makes a few small fixes in prep for the Exhibits site launch: 
- removes unneeded styles for the about page
- adjusts the style of the exhibit end date 
- adjusts the card image positioning on small screens
- adds page content to the homepage
- fixes some broken links to about page
- fixes the sort order on the full exhibits listing page

Code review: @matt-bernhardt 
