### PR TITLE
add gallery name to single exhibit view

### DIFF
--- a/single-exhibits.php
+++ b/single-exhibits.php
@@ -24,6 +24,9 @@ get_template_part( 'inc/breadcrumbs', 'child' );
 			<?php while ( have_posts() ) : the_post(); ?>
 
 				<div class="article-head">
+					<?php foreach ( (get_the_category()) as $category ) { ?>
+						<p class="title-sub"><?php echo esc_attr( $category->cat_name ); ?> Exhibit</p>
+					<?php } ?>
 
 					<h2><?php the_title(); ?></h2>
 					<?php if ( get_field( 'subtitle' ) ) : ?>


### PR DESCRIPTION
This PR adds the gallery name to the top of the single exhibit page so users know where the exhibit is when they are looking at the details ("Maihaugan Gallery Exhibit" at the top in the image below). 

Code review: @matt-bernhardt 

<img width="408" alt="screen shot 2016-09-27 at 11 57 16 am" src="https://cloud.githubusercontent.com/assets/4327102/18881506/965f7754-84a9-11e6-8d5f-6590938a20ab.png">
