### PR TITLE
Restores search functionality

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -780,6 +780,11 @@ footer .footerHeader {
 	margin-bottom: 2em;
 }
 
+/* ---- Search Results ---- */
+.search-results .post {
+	margin: 2em 0;
+}
+
 /* ---- TO-GO ---- */
 .hide-title .widget-title,
 .screen-reader-text {

--- a/functions.php
+++ b/functions.php
@@ -153,22 +153,6 @@ add_filter('single_template', create_function(
 	return $the_template;' )
 );
 
-/**
- * Load all custom post_types if home page or search results.
- *
- * @param object $query A wordpress query object.
- */
-function search_filter( $query ) {
-	if ( ! is_admin() && $query->is_main_query() ) {
-		if ( $query->is_home() || $query->is_search() ) {
-			$query->set( 'post_type', array( 'maihaugen', 'rotch', 'online' ) );
-		}
-	}
-}
-add_action( 'pre_get_posts','search_filter' );
-
-
-
 
 if ( function_exists( 'add_theme_support' ) ) { add_theme_support( 'post-thumbnails' ); }
 

--- a/inc/post-searchresult.php
+++ b/inc/post-searchresult.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * The template for displaying a post as a search result.
+ *
+ * @package MIT_Libraries_Child
+ * @since 2.2.1
+ */
+
+$post_id = get_the_ID();
+
+if ( is_home() ) {
+	$header_open = '<h2 id="post-' . $post_id . '">';
+	$header_close = '</h2>';
+}
+
+if ( is_search() || is_category() ) {
+	$header_open = '<h3 id="post-' . $post_id . '">';
+	$header_close = '</h3>';
+}
+
+$allowed = array(
+	'h2' => array(
+		'id' => array(),
+	),
+	'h3' => array(
+		'id' => array(),
+	),
+);
+
+?>
+
+<div class="post">
+
+	<?php echo wp_kses( $header_open, $allowed ); ?>
+		<a href="<?php the_permalink() ?>" rel="bookmark" title="Permanent Link to <?php the_title(); ?>">
+			<?php the_post_thumbnail( array( 50, 50 ) ); ?>
+			<?php the_title(); ?>
+		</a>
+	<?php echo wp_kses( $header_close, $allowed ); ?>
+	
+	<?php edit_post_link( '(Edit)' ); ?> </p>
+
+</div>

--- a/search.php
+++ b/search.php
@@ -28,7 +28,7 @@ get_header(); ?>
 				<?php /* Start the Loop */ ?>
 				<?php while ( have_posts() ) : the_post(); ?>
 
-					<?php get_template_part( 'inc/post', 'trimmed' ); ?>
+					<?php get_template_part( 'inc/post', 'searchresult' ); ?>
 
 				<?php endwhile; ?>
 

--- a/search.php
+++ b/search.php
@@ -8,48 +8,52 @@
 
 get_header(); ?>
 
-	<?php get_template_part( 'inc/breadcrumbs', 'child' ); ?>
+<?php get_template_part( 'inc/breadcrumbs', 'child' ); ?>
 
-		<div id="stage" class="inner group" role="main">
+<div id="stage" class="inner group" role="main">
 
-			<?php get_template_part( 'inc/postHead' ); ?>
+	<?php get_template_part( 'inc/postHead' ); ?>
 
-			<div id="content" class="allContent hasSidebar group">
+	<div id="content" class="allContent hasSidebar group">
 
-				<div class="mainContent group">
+		<div class="mainContent group">
 
-					<?php if ( have_posts() ) : ?>
+			<?php if ( have_posts() ) : ?>
 
-						<?php /* translators: Header containing submitted search string */ ?>
-						<h2 class="page-title search-title"><?php printf( __( 'Search Results for: %s', 'twentytwelve' ), '<span>' . get_search_query() . '</span>' ); ?></h2>
+				<?php /* translators: Header containing submitted search string */ ?>
+				<h2 class="page-title search-title"><?php printf( esc_html__( 'Search Results for: %s', 'twentytwelve' ), '<span>' . get_search_query() . '</span>' ); ?></h2>
 
-						<?php twentytwelve_content_nav( 'nav-above' ); ?>
+				<?php twentytwelve_content_nav( 'nav-above' ); ?>
 
-						<?php /* Start the Loop */ ?>
-						<?php while ( have_posts() ) : the_post(); ?>
-							
-							<?php get_template_part( 'inc/post', 'trimmed' ); ?>
+				<?php /* Start the Loop */ ?>
+				<?php while ( have_posts() ) : the_post(); ?>
 
-						<?php endwhile; ?>
+					<?php get_template_part( 'inc/post', 'trimmed' ); ?>
 
-						<?php twentytwelve_content_nav( 'nav-below' ); ?>
+				<?php endwhile; ?>
 
-					<?php else : ?>
+				<?php twentytwelve_content_nav( 'nav-below' ); ?>
 
-						<article id="post-0" class="post no-results not-found">
+			<?php else : ?>
 
-								<h2 class="entry-title search-title"><?php _e( 'Nothing Found', 'twentytwelve' ); ?></h2>
+				<article id="post-0" class="post no-results not-found">
 
-							<div class="entry-content">
-								<p><?php _e( 'Sorry, but nothing matched your search criteria. Please try again with some different keywords.', 'twentytwelve' ); ?></p>
-								<?php get_search_form(); ?>
-							</div><!-- .entry-content -->
-						</article><!-- #post-0 -->
+						<h2 class="entry-title search-title"><?php esc_html_e( 'Nothing Found', 'twentytwelve' ); ?></h2>
 
-					<?php endif; ?>
+					<div class="entry-content">
+						<p><?php esc_html_e( 'Sorry, but nothing matched your search criteria. Please try again with some different keywords.', 'twentytwelve' ); ?></p>
+						<?php get_search_form(); ?>
+					</div><!-- .entry-content -->
+				</article><!-- #post-0 -->
+
+			<?php endif; ?>
 
 		</div><!-- .mainContent -->
+
 		<?php get_sidebar(); ?>
+
 	</div><!-- .allContent -->
+
 </div><!-- #stage -->
+
 <?php get_footer(); ?>


### PR DESCRIPTION
There's a `search_filter()` function in functions.php that restricts search activity to three no-longer-extant post types: maihaugen, rotch, and online. This branch removes that filter, allowing search to happen across the standard post types.

There will be a related branch in MITLibraries/Custom-Child-Theme-Post-Types that will add the custom post types defined by that plugin to any site that enables it.

Along the way, this branch also fixes the following existing problems:

* Switches to esc_html_e() from __() and _e() - Unsafe printing functions
* Fixes indenting problems in search.php