### PR TITLE
Updates Travis, whitelist, NPM tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@
 # For use with the MIT Libraries' child theme.
 # @link https://github.com/MITLibraries/MITlibraries-child
 
+# Declare what Travis environment should be used. Specifically, we need the
+# 'precise' environment rather than 'trusty' to get PHP 5.3.
+dist: precise
+
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
@@ -24,10 +28,10 @@ env:
   # @link https://github.com/WordPress/WordPress
   # WP_VERSION=master WP_MULTISITE=0
   - WP_VERSION=master WP_MULTISITE=1
-  # WordPress 4.7
-  # @link https://github.com/WordPress/WordPress/tree/4.7-branch
-  # WP_VERSION=4.7 WP_MULTISITE=0
-  - WP_VERSION=4.7 WP_MULTISITE=1
+  # WordPress 4.8
+  # @link https://github.com/WordPress/WordPress/tree/4.8-branch
+  # WP_VERSION=4.8 WP_MULTISITE=0
+  - WP_VERSION=4.8 WP_MULTISITE=1
 
 # Declare "future" releases to be acceptable failures.
 # @link https://buddypress.trac.wordpress.org/ticket/5620
@@ -74,7 +78,7 @@ before_script:
   # Hop into CodeSniffer directory.
   - cd php-codesniffer
   # Checkout pre 3.x version
-  - git checkout tags/2.9.0
+  - git checkout tags/2.9.1
   # Set install path for WordPress Coding Standards.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
   - scripts/phpcs --config-set installed_paths ../wordpress-coding-standards

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -19,16 +19,28 @@
 		<exclude name="Generic.Files.LowercasedFilename.NotFound" />
 		<exclude name="Generic.Strings.UnnecessaryStringConcat.Found" />
 		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
+		<exclude name="Squiz.ControlStructures.ControlSignature.NewlineAfterOpenBrace" />
+		<exclude name="Squiz.Commenting.LongConditionClosingComment.Invalid" />
+		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterEnd" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentAfterOpen" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeOpen" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.NoSemicolon" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingAfterOpen" />
+		<exclude name="Squiz.PHP.EmbeddedPhp.SpacingBeforeClose" />
 		<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound" />
+		<exclude name="WordPress.Arrays.ArrayIndentation.CloseBraceNotAligned" />
+		<exclude name="WordPress.Arrays.ArrayIndentation.ItemNotAligned" />
+		<exclude name="WordPress.Arrays.CommaAfterArrayItem.NoSpaceAfterComma" />
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid" />
 		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
 		<exclude name="WordPress.VIP.PostsPerPage.posts_per_page_posts_per_page" />
 		<exclude name="WordPress.VIP.RestrictedFunctions.get_term_link_get_category_link" />
 		<exclude name="WordPress.VIP.RestrictedFunctions.switch_to_blog_switch_to_blog" />
+		<exclude name="WordPress.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed" />
 		<exclude name="WordPress.XSS.EscapeOutput.OutputNotEscaped" />
 		<exclude name="WordPress.XSS.EscapeOutput.UnsafePrintingFunction" />
-		<exclude name="Squiz.Commenting.LongConditionClosingComment.Invalid" />
-		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing" />
 	</rule> 
 </ruleset>

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   },
   "homepage": "https://github.com/MITLibraries/MITLibraries-child#readme",
   "devDependencies": {
-    "glob": "^7.0.3",
+    "glob": "^7.1.2",
     "grunt": "^1.0.1",
     "grunt-gitinfo": "^0.1.8",
     "grunt-replace": "^1.0.1"
   },
   "dependencies": {
-    "load-grunt-tasks": "^3.5.0"
+    "load-grunt-tasks": "^3.5.2"
   }
 }


### PR DESCRIPTION
This PR is part of the move to update tooling integrations. The relevant JIRA ticket is [NTI-111](https://mitlibraries.atlassian.net/browse/NTI-111).

There are five changes, most involving Travis/CodeSniffer and one to the NPM/Grunt build system.

- [x] Update what template Travis uses to run its checks (the default VM no longer has PHP 5.3)
- [x] Update what version of WordPress is used for testing (from 4.7 to 4.8)
- [x] Update what version of CodeSniffer is used (from 2.9.0 to 2.9.1)
- [x] Add all failing tests to the project whitelist
- [x] Update relevant NPM packages used by the Grunt build system.

More whitelisting will probably be needed based on the outcome of MITLibraries/MITLibraries-child#135. Additionally a cleaning pass of the theme is probably in order to cut down on the number of code violations - but that's not part of this scope.