### PR TITLE
Adds PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Status
+_Use labels (`review needed`, `in progress`, or `paused`) to declare status_
+
+#### What does this PR do?
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context (if appropriate)
+
+#### How can a reviewer manually see the effects of these changes?
+
+#### What are the relevant tickets?
+- https://mitlibraries.atlassian.net/browse/NTI-
+
+#### Screenshots (if appropriate)
+
+#### Todo:
+- [ ] Documentation
+- [ ] Stakeholder approval
+
+#### Requires new or updated plugins, themes, or libraries?
+YES | NO
+
+#### Requires change to deploy process?
+YES | NO


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?

This adds a template that will pre-populate all pull requests with a suggested set of content - which is then edited by the person proposing the change. The goal of the change is to align this project with the process first adopted by the MITLibraries/bento project.

Having a PR template should help make code reviews easier, by ensuring that developers provide the context necessary for reviewers to understand the change.

#### Helpful background context (if appropriate)

This is the same change as MITLibraries/MITLibraries-parent#223

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-132

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
