### PR TITLE
Remove spaces around object operators

### DIFF
--- a/inc/breadcrumbs-category.php
+++ b/inc/breadcrumbs-category.php
@@ -16,7 +16,7 @@
 
 	foreach ( get_the_category( $post_id ) as $cat ) {
 		$categ = get_category( $cat );
-		array_push( $cats, $categ -> name );
+		array_push( $cats, $categ->name );
 	}
 
 	$post_categories = implode( ', ', $cats );

--- a/single.php
+++ b/single.php
@@ -37,7 +37,7 @@ get_template_part( 'inc/breadcrumbs', 'child' );
 					$cats = array();
 					foreach ( get_the_category( $post_id ) as $cat ) {
 						$categ = get_category( $cat );
-						array_push( $cats, $categ -> name );
+						array_push( $cats, $categ->name );
 					}
 
 					$post_categories = implode( ', ', $cats );


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?

This resolves a recently-appearing violation in Travis/PHPCS that has to do with spacing around object operators. While in many cases coding standards call for spacing around just about everything, this is one case where `foo->bar` is more appropriate than `foo -> bar`.

#### Helpful background context (if appropriate)

While we don't use all of the PSR-2 standard, their example code does show what I think we're looking for at this URL:

http://www.php-fig.org/psr/psr-2/#11-example

#### How can a reviewer manually see the effects of these changes?

This should have no visible effect - but the tests on Travis should now pass. The affected templates are the single post display and the category breadcrumb - so if pages using those templates still work, there will be no side effect.

One path to check, that uses `single.php`, is to visit `/libtest/2016/02/sample-openseadragon-gallery` and verify that the page loads, categories are visible, and What The File reports the use of `single.php`.

I'm having a hard time finding a page that uses `inc/breadcrumbs-category.php`

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-136

#### Todo:
- [X] Documentation
- [X] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
