### PR TITLE
show MIT logo in slim header always

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,6 +61,11 @@ b, strong {
 
 /* ---- Begin Child Page Content Styles ---- */
 
+.childTheme .header-slim {
+	justify-content: space-between;
+	padding: 0 1em;
+}
+
 .childTheme .header-slim .name-site {
 	margin: .5rem 1.5%;
 	padding: 0;
@@ -70,6 +75,14 @@ b, strong {
 	max-height: 2rem;
 }
 
+.childTheme .header-main.header-slim .link-site-search, 
+.childTheme .header-main.header-slim .link-account {
+	display: none;
+}
+
+.childTheme .header-main.header-slim .link-logo-mit {
+	display: block;
+}
 
 .childTheme .betterBreadcrumbs {
 	background:#eceaea;


### PR DESCRIPTION
#### What does this PR do?
Hides the search and account links and shows the MIT logo in the slim header. 

#### How can a reviewer manually see the effects of these changes?
On test: 
https://libraries-test.mit.edu/new-creos/
Shrink the browser window and you will see the MIT logo on the top right for all sizes. 

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-509

#### Screenshots (if appropriate)
Before: 
<img width="376" alt="Screen Shot 2019-05-16 at 3 36 11 PM" src="https://user-images.githubusercontent.com/4327102/57885292-a11ae580-77f8-11e9-80d5-28a86bcf7b8f.png">

After: 
![Screen Shot 2019-05-17 at 10 44 40 AM](https://user-images.githubusercontent.com/4327102/57935887-ce1ad700-7890-11e9-949e-8bf19c0078ac.png)

