### PR TITLE
Explicitly sets child theme homepages to use white background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -699,6 +699,12 @@ dd.wp-caption-text {
 	display:inline-block;
 }
 
+body.childTheme.page-home {
+	background-color: #fff;
+	color: #000;
+
+}
+
 .childTheme.page-home .flexItem {
 	max-width:100%;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries Child NEW
 Author: Lightning Trumpet & MIT Libraries
 Author URI: http://wordpress.org/
-Version: 2.2.2-@@branch-@@commit
+Version: 2.2.3-@@branch-@@commit
 
 Template: libraries
 
@@ -702,7 +702,6 @@ dd.wp-caption-text {
 body.childTheme.page-home {
 	background-color: #fff;
 	color: #000;
-
 }
 
 .childTheme.page-home .flexItem {

--- a/functions.php
+++ b/functions.php
@@ -37,7 +37,7 @@ function enqueue_my_styles() {
 	wp_enqueue_style( 'bootstrap', '//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css' );
 	wp_enqueue_style( 'font-awesome', '//maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css' );
 	// Then enqueues the child stylesheet with a dependency on the parent style, which _should_ enforce correct load order.
-	wp_enqueue_style( 'child-style', get_stylesheet_uri(), array( 'libraries-global' ) );
+	wp_enqueue_style( 'child-style', get_stylesheet_uri(), array( 'libraries-global' ), '2.2.3' );
 }
 add_action( 'wp_enqueue_scripts', 'enqueue_my_styles' );
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries Child NEW
 Author: Lightning Trumpet & MIT Libraries
 Author URI: http://wordpress.org/
-Version: 2.2.2-@@branch-@@commit
+Version: 2.2.3-@@branch-@@commit
 
 Template: libraries
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds some explicit styling to the child theme to set the home page to use a white background and black test. This became necessary because a recent update to the parent theme has allowed some sites to use a black-background styling, which wasn't intended. The markup that allows this to occur is inconsistently being applied, so it seems fastest to just explicitly set the colors here in the child theme for those sites to protect them from inconsistent behavior of the parent theme.

#### Helpful background context (if appropriate)
Ideally I'd like to identify the root cause of why the markup isn't being created correctly - but there are some high profile news items coming out today for the Scholarly site, so I'd rather just squash the problem this way and debug with more time later.

#### How can a reviewer manually see the effects of these changes?
Details with links are in Slack

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-564

#### Screenshots (if appropriate)
Scholarly in production:
![image](https://user-images.githubusercontent.com/1403248/67420256-443c0c00-f59c-11e9-95bb-14d212766653.png)

Scholarly on the staging site:
![image](https://user-images.githubusercontent.com/1403248/67420284-53bb5500-f59c-11e9-9215-ad95d573e8cb.png)

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
