### PR TITLE
Removes create_function call to prepare for PHP 7.2

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -149,8 +149,8 @@ add_filter(
 	'single_template',
 	function( $the_template ) {
 		foreach ( (array) get_the_category() as $cat ) {
-			if ( file_exists( STYLESHEETPATH . "/single-{$cat->slug}.php" ) ) {
-				return STYLESHEETPATH . "/single-{$cat->slug}.php";
+			if ( file_exists( get_stylesheet_directory() . "/single-{$cat->slug}.php" ) ) {
+				return get_stylesheet_directory() . "/single-{$cat->slug}.php";
 			}
 		}
 		return $the_template;

--- a/functions.php
+++ b/functions.php
@@ -145,14 +145,17 @@ if ( ! function_exists( 'register_child_nav' ) ) {
 }
 
 // Gets post cat slug and looks for single-[cat slug].php and applies it.
-add_filter('single_template', create_function(
-		'$the_template',
-		'foreach( (array) get_the_category() as $cat ) {
-		if ( file_exists(STYLESHEETPATH . "/single-{$cat->slug}.php") )
-		return STYLESHEETPATH . "/single-{$cat->slug}.php"; }
-	return $the_template;' )
+add_filter(
+	'single_template',
+	function( $the_template ) {
+		foreach ( (array) get_the_category() as $cat ) {
+			if ( file_exists( STYLESHEETPATH . "/single-{$cat->slug}.php" ) ) {
+				return STYLESHEETPATH . "/single-{$cat->slug}.php";
+			}
+		}
+		return $the_template;
+	}
 );
-
 
 if ( function_exists( 'add_theme_support' ) ) { add_theme_support( 'post-thumbnails' ); }
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This refactors the application of a filter in `functions.php` to avoid a deprecated PHP function, `create_function()`.

#### Helpful background context (if appropriate)
There's a ton of background links in the Jira ticket. Ultimately, this should be a pretty simple refactor if the examples I'm finding are applicable.

#### How can a reviewer manually see the effects of these changes?
The Special Collections site has a variety of slideshows that trigger warnings in our logs. Tailing the error log while visiting these pages should show now messages that refer to a deprecated create_functions call.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/ENGX-16

#### Screenshots (if appropriate)

#### Todo:
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
YES | NO

#### Requires change to deploy process?
YES | NO
