### PR TITLE
Adjust styles around sidebar and staff widgets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries Child NEW
 Author: Lightning Trumpet & MIT Libraries
 Author URI: http://wordpress.org/
-Version: 2.2.3-@@branch-@@commit
+Version: 2.2.4-@@branch-@@commit
 
 Template: libraries
 
@@ -961,10 +961,8 @@ footer .footerHeader {
 	clear: both;
 }
 
-.childTheme .staff-widget {
-	float: left;
-	width: 30%;
-	margin-right: 5%;
+.staff-widget {
+	margin-top: 1em;
 }
 
 .entry-content .staff-widget .textwidget,
@@ -1300,6 +1298,11 @@ a.px14 {
 		width: 100%;
 		margin-bottom: 50px;
 		float: none;
+	}
+
+	.childTheme .has-sidebar .sidebar {
+		clear: both;
+		padding-top: 50px;
 	}
 
 	ul.nav li.dropdown:hover > ul.dropdown-menu {

--- a/functions.php
+++ b/functions.php
@@ -37,7 +37,7 @@ function enqueue_my_styles() {
 	wp_enqueue_style( 'bootstrap', '//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css' );
 	wp_enqueue_style( 'font-awesome', '//maxcdn.bootstrapcdn.com/font-awesome/4.6.0/css/font-awesome.min.css' );
 	// Then enqueues the child stylesheet with a dependency on the parent style, which _should_ enforce correct load order.
-	wp_enqueue_style( 'child-style', get_stylesheet_uri(), array( 'libraries-global' ), '2.2.3' );
+	wp_enqueue_style( 'child-style', get_stylesheet_uri(), array( 'libraries-global' ), '2.2.4' );
 }
 add_action( 'wp_enqueue_scripts', 'enqueue_my_styles' );
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name: MIT Libraries Child NEW
 Author: Lightning Trumpet & MIT Libraries
 Author URI: http://wordpress.org/
-Version: 2.2.3-@@branch-@@commit
+Version: 2.2.4-@@branch-@@commit
 
 Template: libraries
 


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This updates the styling applied to the staff widgets feature, visible mostly on the AKDC site's staff page. There is some wonkiness in how widgets are aligned, which we want to iron out.

This PR rips out bespoke styles, in conjunction with recommending that site builders apply the existing `twoup-widget` and `threeup-widget` classes in order for the staff boxes to appear two-wide or three-wide.

Some spacing around the widget area is also adjusted, and the theme version is bumped to 2.2.4 as a cache-buster.

#### How can a reviewer manually see the effects of these changes?
The changes are on staging - the review URL is in the ticket.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-1130

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
