### PR TITLE
Adds generic "Location index" page template, other exhibit display changes

### DIFF
--- a/inc/exhibits-detail.php
+++ b/inc/exhibits-detail.php
@@ -8,53 +8,46 @@
  * @since 2.0.0
  */
 
-$locations_link = site_url() . '/' . esc_attr( str_replace( ' ','-',get_field( 'location' ) ) );
+$locations_link = site_url() . '/' . esc_attr( str_replace( ' ', '-', get_field( 'location' ) ) );
 ?>
-
-
-			<div class="exhibits-feed">
-				<div class="entry-categories">
-					<div class="entry-cats-list">
-
-							<a href="<?php echo $locations_link ?>"><span class="category-bg"><span class="category-init"><?php echo esc_attr( substr( get_field( 'location' ),0,1 ) ); ?></span></span><span class="cat-name"><?php the_field( 'location' ) ?> Exhibit</span></a>
-					
-					</div>
+<div class="exhibits-feed">
+	<div class="entry-categories">
+		<div class="entry-cats-list">
+			<a href="<?php echo esc_url( $locations_link ); ?>"><span class="category-bg"><span class="category-init"><?php echo esc_attr( substr( get_field( 'location' ), 0, 1 ) ); ?></span></span><span class="cat-name"><?php the_field( 'location' ); ?> Exhibit</span></a>
 		</div>
-
-		<div class="category-post">
-					<div class="category-image" style="background-image: url('<?php get_stylesheet_directory_uri();
-						the_field( 'exhibit_thumbnail_image' ); ?>');">
-					</div>
-					<div class="category-post-content">
-						<h4><a class="exhibit-title" href="<?php the_permalink(); ?>"><?php the_title();?></a></h4>
-						<div class="entry-summary">
-						 	<?php if ( get_field( 'excerpt' ) ) { ?>
-			              	 	<p><?php the_field( 'excerpt' ); ?></p>
-					     	<?php  } else { ?>
-			              		<p><?php custom_excerpt( 35, '...' ) ?></p>
-			            	<?php } ?>
-						</div>
-						<div class="exhibit-ends">
-
-						<?php
-						$today = new DateTime( date( 'Y-m-d' ) );
-						$start = new DateTime( get_field( 'start_date' ) );
-						$end = new DateTime( get_field( 'end_date' ) );
-						if ( $end < $today ) { ?>	
-							Ended <?php the_field( 'end_date' ); ?>
-						<?php } elseif ( $start > $today ) { ?>
-							Opens <?php the_field( 'start_date' ); ?>
-						<?php } else { ?>	
-							<?php the_field( 'start_date' ); ?> - <?php the_field( 'end_date' ); ?>
-						<?php } ?>
-						</div>
-					</div>
-				</div>
-
-				<?php if ( get_field( 'sponsored' ) ) : ?>
-					<div class="sponsored-excerpt">
-					<?php the_field( 'sponsored' ); ?>
-					</div>
-				<?php endif; ?>
-
+	</div>
+	<div class="category-post">
+		<div class="category-image" style="background-image: url('<?php get_stylesheet_directory_uri(); ?>
+			<?php the_field( 'exhibit_thumbnail_image' ); ?>');">
+		</div>
+		<div class="category-post-content">
+			<h4><a class="exhibit-title" href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h4>
+			<div class="entry-summary">
+				<?php if ( get_field( 'excerpt' ) ) { ?>
+					<p><?php the_field( 'excerpt' ); ?></p>
+				<?php } else { ?>
+					<p><?php custom_excerpt( 35, '...' ); ?></p>
+				<?php } ?>
 			</div>
+			<div class="exhibit-ends">
+				<?php
+				$today = new DateTime( gmdate( 'Y-m-d' ) );
+				$start = new DateTime( get_field( 'start_date' ) );
+				$end = new DateTime( get_field( 'end_date' ) );
+				if ( $end < $today ) {
+					?>
+					Ended <?php the_field( 'end_date' ); ?>
+				<?php } elseif ( $start > $today ) { ?>
+					Opens <?php the_field( 'start_date' ); ?>
+				<?php } else { ?>	
+					<?php the_field( 'start_date' ); ?> - <?php the_field( 'end_date' ); ?>
+				<?php } ?>
+			</div>
+		</div>
+	</div>
+	<?php if ( get_field( 'sponsored' ) ) : ?>
+		<div class="sponsored-excerpt">
+		<?php the_field( 'sponsored' ); ?>
+		</div>
+	<?php endif; ?>
+</div>

--- a/inc/exhibits-detail.php
+++ b/inc/exhibits-detail.php
@@ -8,12 +8,12 @@
  * @since 2.0.0
  */
 
-$locations_link = site_url() . '/' . esc_attr( str_replace( ' ', '-', get_field( 'location' ) ) );
+$location_info = get_exhibit_location();
 ?>
 <div class="exhibits-feed">
 	<div class="entry-categories">
 		<div class="entry-cats-list">
-			<a href="<?php echo esc_url( $locations_link ); ?>"><span class="category-bg"><span class="category-init"><?php echo esc_attr( substr( get_field( 'location' ), 0, 1 ) ); ?></span></span><span class="cat-name"><?php the_field( 'location' ); ?> Exhibit</span></a>
+			<a href="<?php echo esc_url( $location_info['link'] ); ?>"><span class="category-bg"><span class="category-init"><?php echo esc_html( $location_info['initial'] ); ?></span></span><span class="cat-name"><?php echo esc_html( $location_info['name'] ); ?> Exhibit</span></a>
 		</div>
 	</div>
 	<div class="category-post">
@@ -39,7 +39,7 @@ $locations_link = site_url() . '/' . esc_attr( str_replace( ' ', '-', get_field(
 					Ended <?php the_field( 'end_date' ); ?>
 				<?php } elseif ( $start > $today ) { ?>
 					Opens <?php the_field( 'start_date' ); ?>
-				<?php } else { ?>	
+				<?php } else { ?>
 					<?php the_field( 'start_date' ); ?> - <?php the_field( 'end_date' ); ?>
 				<?php } ?>
 			</div>

--- a/page-exhibits-feed.php
+++ b/page-exhibits-feed.php
@@ -29,7 +29,7 @@ get_header( 'child' );
 					'meta_key'    => 'start_date',  // Load up the event_date meta.
 					'orderby'     => 'start_date',
 					'order'       => 'DESC',      // Descending, so later events first.
-					'meta_query'  => array(
+					'meta_query'  => array( // The meta_query is an array of query items.
 						array(
 							'key'     => 'start_date',     // Which meta to query.
 							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
@@ -37,11 +37,20 @@ get_header( 'child' );
 							'type'    => 'DATE',
 						),
 						array(
-							'key'     => 'end_date',       // Which meta to query.
-							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
-							'compare' => '>=',             // Method of comparison.
-							'type'    => 'DATE',
-						), // The meta_query is an array of query items.
+							'relation' => 'OR',
+							array(
+								'key'     => 'end_date',        // Which meta to query.
+								'value'   => gmdate( 'Y-m-d' ), // Value for comparison.
+								'compare' => '>=',              // Method of comparison.
+								'type'    => 'DATE',
+							),
+							array(
+								'key'     => 'end_date',       // Which meta to query.
+								'value'   => '',               // Value for comparison.
+								'compare' => '=',              // Method of comparison.
+								'type'    => 'CHAR',
+							),
+						),
 					), // End meta_query array.
 				) // End array.
 			); // Close WP_Query constructor call.

--- a/page-exhibits-feed.php
+++ b/page-exhibits-feed.php
@@ -23,13 +23,13 @@ get_header( 'child' );
 
 			$current_query = new WP_Query(
 				array(
-					'posts_per_page' => 10,
+					'posts_per_page'      => 10,
 					'ignore_sticky_posts' => false,
-					'post_type'   => 'exhibits',  // Only query exhibits.
-					'meta_key'    => 'start_date',  // Load up the event_date meta.
-					'orderby'     => 'start_date',
-					'order'       => 'DESC',      // Descending, so later events first.
-					'meta_query'  => array( // The meta_query is an array of query items.
+					'post_type'           => 'exhibits',  // Only query exhibits.
+					'meta_key'            => 'start_date',  // Load up the event_date meta.
+					'orderby'             => 'start_date',
+					'order'               => 'DESC',      // Descending, so later events first.
+					'meta_query'          => array( // The meta_query is an array of query items.
 						array(
 							'key'     => 'start_date',     // Which meta to query.
 							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
@@ -87,12 +87,12 @@ get_header( 'child' );
 
 		$future_query = new WP_Query(
 			array(
-				'post_type'   => 'exhibits',    // Only query exhibits.
-				'meta_key'    => 'start_date',  // Load up the event_date meta.
-				'orderby'    => 'start_date',
-				'order'       => 'ASC',
+				'post_type'      => 'exhibits',    // Only query exhibits.
+				'meta_key'       => 'start_date',  // Load up the event_date meta.
+				'orderby'        => 'start_date',
+				'order'          => 'ASC',
 				'posts_per_page' => 10,       // Descending, so later events first.
-				'meta_query'  => array(
+				'meta_query'     => array(
 					array(
 						'key'     => 'start_date',     // Which meta to query.
 						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.

--- a/page-exhibits-feed.php
+++ b/page-exhibits-feed.php
@@ -32,27 +32,29 @@ get_header( 'child' );
 					'meta_query'  => array(
 						array(
 							'key'     => 'start_date',     // Which meta to query.
-							'value'   => date( 'Y-m-d' ),  // Value for comparison.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 							'compare' => '<=',             // Method of comparison.
 							'type'    => 'DATE',
 						),
 						array(
 							'key'     => 'end_date',       // Which meta to query.
-							'value'   => date( 'Y-m-d' ),  // Value for comparison.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 							'compare' => '>=',             // Method of comparison.
 							'type'    => 'DATE',
 						), // The meta_query is an array of query items.
 					), // End meta_query array.
 				) // End array.
 			); // Close WP_Query constructor call.
-		?> 
-        
+			?>
+
 			<div class="exhibits-feed-section">
 			
 				<h3 class="title-sub">Current Exhibits</h3>
 						 
-				<?php if ( $current_query->have_posts() ) :
-					while ( $current_query->have_posts() ) : $current_query->the_post(); // Loop for current exhibits.
+				<?php
+				if ( $current_query->have_posts() ) :
+					while ( $current_query->have_posts() ) :
+						$current_query->the_post(); // Loop for current exhibits.
 
 						get_template_part( 'inc/exhibits-detail' );
 
@@ -60,12 +62,13 @@ get_header( 'child' );
 
 						wp_reset_postdata();
 
-				else : ?>
+				else :
+					?>
 		 
 					<p><?php esc_html_e( 'There are no current exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
 		 
 				<?php endif; ?>
-			   		   
+					   
 			</div>
 
 		<!-- END OF CURRENT EXHIBITS LOOP -->
@@ -74,30 +77,32 @@ get_header( 'child' );
 		<?php
 
 		$future_query = new WP_Query(
-	        array(
-	          	'post_type'   => 'exhibits',    // Only query exhibits.
-	          	'meta_key'    => 'start_date',  // Load up the event_date meta.
-	          	'orderby'    => 'start_date',
-	          	'order'       => 'ASC',
-	          	'posts_per_page' => 10,       // Descending, so later events first.
-	          	'meta_query'  => array(
-	             	array(
-	              		'key'     => 'start_date',     // Which meta to query.
-	              		'value'   => date( 'Y-m-d' ),  // Value for comparison.
-	              		'compare' => '>',             // Method of comparison.
-	              		'type'    => 'DATE',
-	            	), // The meta_query is an array of query items.
-	           	), // End meta_query array.
-	         ) // End array.
-	    ); // Close WP_Query constructor call.
-		?> 
+			array(
+				'post_type'   => 'exhibits',    // Only query exhibits.
+				'meta_key'    => 'start_date',  // Load up the event_date meta.
+				'orderby'    => 'start_date',
+				'order'       => 'ASC',
+				'posts_per_page' => 10,       // Descending, so later events first.
+				'meta_query'  => array(
+					array(
+						'key'     => 'start_date',     // Which meta to query.
+						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+						'compare' => '>',             // Method of comparison.
+						'type'    => 'DATE',
+					), // The meta_query is an array of query items.
+				), // End meta_query array.
+			) // End array.
+		); // Close WP_Query constructor call.
+		?>
 			
 			<div class="exhibits-feed-section">
 				
 				<h3 class="title-sub">Upcoming Exhibits</h3>
 				 
-				<?php if ( $future_query->have_posts() ) :
-					while ( $future_query->have_posts() ) : $future_query->the_post(); // Loop for future exhibits.
+				<?php
+				if ( $future_query->have_posts() ) :
+					while ( $future_query->have_posts() ) :
+						$future_query->the_post(); // Loop for future exhibits.
 
 						get_template_part( 'inc/exhibits-detail' );
 
@@ -105,7 +110,8 @@ get_header( 'child' );
 
 					wp_reset_postdata();
 
-				else : ?>
+				else :
+					?>
 	 
 					<p><?php esc_html_e( 'There are no upcoming exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
 	 
@@ -114,53 +120,56 @@ get_header( 'child' );
 			</div>
 		
 		
-		<!-- END OF UPCOMING EXHIBITS LOOP -->
-		 
-		 
-		<?php
+			<!-- END OF UPCOMING EXHIBITS LOOP -->
+			 
+			 
+			<?php
 
-		$past_query = new WP_Query(
-	        array(
-	          	'post_type'   => 'exhibits',  // Only query events.
-	          	'meta_key'    => 'end_date',  // Load up the event_date meta.
-	          	'orderby'    	=> 'end_date',
-	          	'order'       => 'DESC',      // Descending, so later events first.
-	          	'posts_per_page' => 5,
-	          	'meta_query'  => array(
-	            	array(
-	              		'key'     => 'end_date',       // Which meta to query.
-	              		'value'   => date( 'Y-m-d' ),  // Value for comparison.
-	              		'compare' => '<',              // Method of comparison.
-	              		'type'    => 'DATE',
-	           		), // The meta_query is an array of query items.
-	           ), // End meta_query array.
-	        ) // End array.
-		); // Close WP_Query constructor call.
-		?> 
-		
+			$past_query = new WP_Query(
+				array(
+					'post_type'      => 'exhibits',  // Only query events.
+					'meta_key'       => 'end_date',  // Load up the event_date meta.
+					'orderby'        => 'end_date',
+					'order'          => 'DESC',      // Descending, so later events first.
+					'posts_per_page' => 5,
+					'meta_query'     => array(
+						array(
+							'key'     => 'end_date',       // Which meta to query.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+							'compare' => '<',              // Method of comparison.
+							'type'    => 'DATE',
+						), // The meta_query is an array of query items.
+					), // End meta_query array.
+				) // End array.
+			); // Close WP_Query constructor call.
+			?>
+
 			<div class="exhibits-feed-section">
 			
 				<h3 class="title-sub">Past Exhibits</h3>
 				 
-		   <?php while ( $past_query->have_posts() ) : $past_query->the_post(); // Loop for events.
+				<?php
+				while ( $past_query->have_posts() ) :
+					$past_query->the_post(); // Loop for events.
 
-		      		get_template_part( 'inc/exhibits-detail' );
+					get_template_part( 'inc/exhibits-detail' );
 
 					wp_reset_postdata(); // Restore global post data stomped by the_post().
 
-			   endwhile; // End of the loop. ?>
+				endwhile; // End of the loop.
+				?>
 
 			</div>
 
 			<a class="button-secondary exhibits-button" href="/exhibits/past-exhibits/">View all past exhibits</a>
 
 		<!-- END OF PAST EXHIBITS LOOP -->
-    
-  		
-  		
-	  	</div>  <!-- main-content --> 
 	
-	  	<?php get_sidebar(); ?>
+		
+		
+		</div>  <!-- main-content --> 
+	
+		<?php get_sidebar(); ?>
 	
 		</div>   <!-- content --> 
 			

--- a/page-exhibits-location.php
+++ b/page-exhibits-location.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Template Name: Exhibits | Location Index
+ *
+ * @package MIT_Libraries_Child
+ * @since Twenty Twelve 1.0
+ *
+ * This template displays relevant exhibits for a given location, specified
+ * in page content by assigning the page to a given category.
+ *
+ * To use this template:
+ * 1. Create a Page record. The title and body are irrelevant and are not
+ *    displayed by this template.
+ * 2. Assign the Page a single Category value for the location you wish to
+ *    display (For example, "Rotch Library"). PLEASE NOTE: assigning multiple
+ *    Category values to the Page should be avoided - only the first value
+ *    returned by get_the_category() will be used.
+ * 3. Set the Page to display using this page template.
+ * 4. The page will now show Exhibit records which share the same category.
+ */
+
+get_header( 'child' );
+
+// Pages using this template should have one and only one category value. If
+// the page is placed in multiple categories, then the first term returned here
+// will determine which sets of exhibits get displayed.
+$categories    = get_the_category();
+$location_name = $categories[0]->name;
+?>
+
+	<?php get_template_part( 'inc/breadcrumbs', 'child' ); ?>
+
+	<div id="stage" class="inner" role="main">
+
+	<?php get_template_part( 'inc/postHead' ); ?>
+
+		<div id="content" class="content has-sidebar">
+
+			<div class="main-content">
+
+			<?php
+
+			$current_query = new WP_Query(
+				array(
+					'post_type'           => 'exhibits',  // Only query exhibits.
+					'posts_per_page'      => 10,
+					'ignore_sticky_posts' => false,
+					'meta_key'            => 'start_date',
+					'orderby'             => 'start_date',
+					'order'               => 'DESC',      // Descending, so later events first.
+					'meta_query'          => array(
+						array(
+							'key'     => 'start_date',     // Which meta to query.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+							'compare' => '<=',             // Method of comparison.
+							'type'    => 'DATE',
+						),
+						array(
+							'key'     => 'end_date',       // Which meta to query.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+							'compare' => '>=',             // Method of comparison.
+							'type'    => 'DATE',
+						),
+						array(
+							'key'     => 'location',       // Which meta to query.
+							'value'   => $location_name,  // Value for comparison.
+							'compare' => '=',             // Method of comparison.
+							'type'    => 'CHAR',
+						), // The meta_query is an array of query items.
+					), // End meta_query array.
+				) // End array.
+			); // Close WP_Query constructor call.
+			?>
+
+			<div class="exhibits-feed-section">
+
+				<h3 class="title-sub">Current Exhibits</h3>
+
+				<?php
+				if ( $current_query->have_posts() ) :
+					while ( $current_query->have_posts() ) :
+						$current_query->the_post(); // Loop for current exhibits.
+
+						get_template_part( 'inc/exhibits-detail' );
+
+					endwhile;
+
+						wp_reset_postdata();
+
+				else :
+					?>
+
+					<p><?php esc_html_e( 'There are no current exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
+
+				<?php endif; ?>
+
+			</div>
+
+		<!-- END OF CURRENT EXHIBITS LOOP -->
+
+		<?php
+
+		$future_query = new WP_Query(
+			array(
+				'post_type'      => 'exhibits',  // Only query exhibits.
+				'meta_key'       => 'start_date',
+				'posts_per_page' => 10,
+				'orderby'        => 'start_date',
+				'order'          => 'ASC',        // Descending, so later events first.
+				'meta_query'     => array(
+					array(
+						'key'     => 'start_date',     // Which meta to query.
+						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+						'compare' => '>',             // Method of comparison.
+						'type'    => 'DATE',
+					),
+					array(
+						'key'     => 'location',       // Which meta to query.
+						'value'   => $location_name,  // Value for comparison.
+						'compare' => '=',             // Method of comparison.
+						'type'    => 'CHAR',
+					), // The meta_query is an array of query items.
+				), // End meta_query array.
+			) // End array.
+		); // Close WP_Query constructor call.
+		?>
+
+			<div class="exhibits-feed-section">
+
+				<h3 class="title-sub">Upcoming Exhibits</h3>
+
+				<?php
+				if ( $future_query->have_posts() ) :
+					while ( $future_query->have_posts() ) :
+						$future_query->the_post(); // Loop for future exhibits.
+
+						get_template_part( 'inc/exhibits-detail' );
+
+					endwhile;
+
+					wp_reset_postdata();
+
+				else :
+					?>
+
+					<p><?php esc_html_e( 'There are no upcoming exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
+
+				<?php endif; ?>
+
+			</div>
+
+		<!-- END OF UPCOMING EXHIBITS LOOP -->
+
+		<?php
+
+		$past_query = new WP_Query(
+			array(
+				'post_type'      => 'exhibits',  // Only query exhibits.
+				'meta_key'       => 'end_date',
+				'posts_per_page' => 5,
+				'orderby'        => 'end_date',
+				'order'          => 'DESC',      // Descending, so later events first.
+				'meta_query'     => array(
+					array(
+						'key'     => 'end_date',       // Which meta to query.
+						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+						'compare' => '<',              // Method of comparison.
+						'type'    => 'DATE',
+					),
+					array(
+						'key'     => 'location',       // Which meta to query.
+						'value'   => $location_name,  // Value for comparison.
+						'compare' => '=',             // Method of comparison.
+						'type'    => 'CHAR',
+					), // The meta_query is an array of query items.
+				), // End meta_query array.
+			) // End array.
+		); // Close WP_Query constructor call.
+
+		?>
+
+			<div class="exhibits-feed-section">
+
+				<h3 class="title-sub">Past Exhibits</h3>
+
+			<?php
+			while ( $past_query->have_posts() ) :
+				$past_query->the_post(); // Loop for events.
+
+				get_template_part( 'inc/exhibits-detail' );
+
+				wp_reset_postdata(); // Restore global post data stomped by the_post().
+
+			endwhile; // End of the loop.
+			?>
+
+			</div>
+			<!-- END OF UPCOMING EXHIBITS LOOP -->
+			<a class="button-secondary exhibits-button" href="/exhibits/past-exhibits/">View all past exhibits</a>
+
+		</div>  <!-- main-content --> 
+
+		<?php get_sidebar(); ?>
+
+		</div>   <!-- content --> 
+
+	</div>   <!-- stage --> 
+
+<?php get_footer(); ?>

--- a/page-exhibits-location.php
+++ b/page-exhibits-location.php
@@ -43,30 +43,35 @@ $location_name = $categories[0]->name;
 			$current_query = new WP_Query(
 				array(
 					'post_type'           => 'exhibits',  // Only query exhibits.
+					'category_name'       => $location_name,
 					'posts_per_page'      => 10,
 					'ignore_sticky_posts' => false,
 					'meta_key'            => 'start_date',
 					'orderby'             => 'start_date',
 					'order'               => 'DESC',      // Descending, so later events first.
-					'meta_query'          => array(
+					'meta_query'          => array( // The meta_query is an array of query items.
+						'relation' => 'AND',
 						array(
 							'key'     => 'start_date',     // Which meta to query.
 							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 							'compare' => '<=',             // Method of comparison.
 							'type'    => 'DATE',
 						),
-						array(
-							'key'     => 'end_date',       // Which meta to query.
-							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
-							'compare' => '>=',             // Method of comparison.
-							'type'    => 'DATE',
+						array( // Either exhibits with a future end date, or with no end date.
+							'relation' => 'OR',
+							array(
+								'key'     => 'end_date',       // Which meta to query.
+								'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+								'compare' => '>=',             // Method of comparison.
+								'type'    => 'DATE',
+							),
+							array(
+								'key'     => 'end_date',       // Which meta to query.
+								'value'   => '',  // Value for comparison.
+								'compare' => '=',             // Method of comparison.
+								'type'    => 'CHAR',
+							),
 						),
-						array(
-							'key'     => 'location',       // Which meta to query.
-							'value'   => $location_name,  // Value for comparison.
-							'compare' => '=',             // Method of comparison.
-							'type'    => 'CHAR',
-						), // The meta_query is an array of query items.
 					), // End meta_query array.
 				) // End array.
 			); // Close WP_Query constructor call.
@@ -103,6 +108,7 @@ $location_name = $categories[0]->name;
 		$future_query = new WP_Query(
 			array(
 				'post_type'      => 'exhibits',  // Only query exhibits.
+				'category_name'  => $location_name,
 				'meta_key'       => 'start_date',
 				'posts_per_page' => 10,
 				'orderby'        => 'start_date',
@@ -113,12 +119,6 @@ $location_name = $categories[0]->name;
 						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 						'compare' => '>',             // Method of comparison.
 						'type'    => 'DATE',
-					),
-					array(
-						'key'     => 'location',       // Which meta to query.
-						'value'   => $location_name,  // Value for comparison.
-						'compare' => '=',             // Method of comparison.
-						'type'    => 'CHAR',
 					), // The meta_query is an array of query items.
 				), // End meta_query array.
 			) // End array.
@@ -156,6 +156,7 @@ $location_name = $categories[0]->name;
 		$past_query = new WP_Query(
 			array(
 				'post_type'      => 'exhibits',  // Only query exhibits.
+				'category_name'  => $location_name,
 				'meta_key'       => 'end_date',
 				'posts_per_page' => 5,
 				'orderby'        => 'end_date',
@@ -166,12 +167,6 @@ $location_name = $categories[0]->name;
 						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 						'compare' => '<',              // Method of comparison.
 						'type'    => 'DATE',
-					),
-					array(
-						'key'     => 'location',       // Which meta to query.
-						'value'   => $location_name,  // Value for comparison.
-						'compare' => '=',             // Method of comparison.
-						'type'    => 'CHAR',
 					), // The meta_query is an array of query items.
 				), // End meta_query array.
 			) // End array.

--- a/page-exhibits-maihaugen-gallery.php
+++ b/page-exhibits-maihaugen-gallery.php
@@ -19,26 +19,26 @@ get_header( 'child' );
 
 			<div class="main-content">
 
-		<?php
+			<?php
 
 			$current_query = new WP_Query(
 				array(
-					'post_type'   => 'exhibits',  // Only query exhibits.
-					'posts_per_page' => 10,
+					'post_type'           => 'exhibits',  // Only query exhibits.
+					'posts_per_page'      => 10,
 					'ignore_sticky_posts' => false,
-					'meta_key'		=> 'start_date',
-					'orderby'     => 'start_date',
-					'order'       => 'DESC',      // Descending, so later events first.
-					'meta_query'  => array(
+					'meta_key'            => 'start_date',
+					'orderby'             => 'start_date',
+					'order'               => 'DESC',      // Descending, so later events first.
+					'meta_query'          => array(
 						array(
 							'key'     => 'start_date',     // Which meta to query.
-							'value'   => date( 'Y-m-d' ),  // Value for comparison.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 							'compare' => '<=',             // Method of comparison.
 							'type'    => 'DATE',
 						),
 						array(
 							'key'     => 'end_date',       // Which meta to query.
-							'value'   => date( 'Y-m-d' ),  // Value for comparison.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 							'compare' => '>=',             // Method of comparison.
 							'type'    => 'DATE',
 						),
@@ -51,14 +51,17 @@ get_header( 'child' );
 					), // End meta_query array.
 				) // End array.
 			); // Close WP_Query constructor call.
-		?> 
+			?>
 
 			<div class="exhibits-feed-section">
 
 				<h3 class="title-sub">Current Exhibits</h3>
 
-				<?php if ( $current_query->have_posts() ) :
-					while ( $current_query->have_posts() ) : $current_query->the_post(); // Loop for current exhibits.
+				<?php
+				if ( $current_query->have_posts() ) :
+					while ( $current_query->have_posts() ) :
+
+						$current_query->the_post(); // Loop for current exhibits.
 
 						get_template_part( 'inc/exhibits-detail' );
 
@@ -66,7 +69,8 @@ get_header( 'child' );
 
 						wp_reset_postdata();
 
-				else : ?>
+				else :
+					?>
 
 					<p><?php esc_html_e( 'There are no current exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
 
@@ -80,35 +84,38 @@ get_header( 'child' );
 
 		$future_query = new WP_Query(
 			array(
-				'post_type'   => 'exhibits',  // Only query exhibits.
-				'meta_key'		=> 'start_date',
+				'post_type'      => 'exhibits',  // Only query exhibits.
+				'meta_key'       => 'start_date',
 				'posts_per_page' => 10,
-				'orderby'    => 'start_date',
-				'order'       => 'ASC',        // Descending, so later events first.
-				'meta_query'  => array(
+				'orderby'        => 'start_date',
+				'order'          => 'ASC',        // Descending, so later events first.
+				'meta_query'     => array(
 					array(
 						'key'     => 'start_date',     // Which meta to query.
-						'value'   => date( 'Y-m-d' ),  // Value for comparison.
+						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 						'compare' => '>',             // Method of comparison.
 						'type'    => 'DATE',
 					),
 					array(
-							'key'     => 'location',       // Which meta to query.
-							'value'   => 'Maihaugen Gallery',  // Value for comparison.
-							'compare' => '=',             // Method of comparison.
-							'type'    => 'CHAR',
-					),// The meta_query is an array of query items.
+						'key'     => 'location',       // Which meta to query.
+						'value'   => 'Maihaugen Gallery',  // Value for comparison.
+						'compare' => '=',             // Method of comparison.
+						'type'    => 'CHAR',
+					), // The meta_query is an array of query items.
 				), // End meta_query array.
 			) // End array.
 		); // Close WP_Query constructor call.
-		?> 
+		?>
 
 			<div class="exhibits-feed-section">
 
 				<h3 class="title-sub">Upcoming Exhibits</h3>
 
-				<?php if ( $future_query->have_posts() ) :
-					while ( $future_query->have_posts() ) : $future_query->the_post(); // Loop for future exhibits.
+				<?php
+				if ( $future_query->have_posts() ) :
+					while ( $future_query->have_posts() ) :
+
+						$future_query->the_post(); // Loop for future exhibits.
 
 						get_template_part( 'inc/exhibits-detail' );
 
@@ -116,7 +123,8 @@ get_header( 'child' );
 
 					wp_reset_postdata();
 
-				else : ?>
+				else :
+					?>
 
 					<p><?php esc_html_e( 'There are no upcoming exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
 
@@ -130,41 +138,44 @@ get_header( 'child' );
 
 		$past_query = new WP_Query(
 			array(
-				'post_type'   => 'exhibits',  // Only query exhibits.
-	         	'meta_key'		=> 'end_date',
-	         	'posts_per_page' => 5,
-				'orderby'    => 'end_date',
-				'order'       => 'DESC',      // Descending, so later events first.
-				'meta_query'  => array(
+				'post_type'      => 'exhibits',  // Only query exhibits.
+				'meta_key'       => 'end_date',
+				'posts_per_page' => 5,
+				'orderby'        => 'end_date',
+				'order'          => 'DESC',      // Descending, so later events first.
+				'meta_query'     => array(
 					array(
 						'key'     => 'end_date',       // Which meta to query.
-						'value'   => date( 'Y-m-d' ),  // Value for comparison.
+						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 						'compare' => '<',              // Method of comparison.
 						'type'    => 'DATE',
 					),
 					array(
-							'key'     => 'location',       // Which meta to query.
-							'value'   => 'Maihaugen Gallery',  // Value for comparison.
-							'compare' => '=',             // Method of comparison.
-							'type'    => 'CHAR',
+						'key'     => 'location',       // Which meta to query.
+						'value'   => 'Maihaugen Gallery',  // Value for comparison.
+						'compare' => '=',             // Method of comparison.
+						'type'    => 'CHAR',
 					), // The meta_query is an array of query items.
 				), // End meta_query array.
 			) // End array.
 		); // Close WP_Query constructor call.
 
-		?> 
+		?>
 
 			<div class="exhibits-feed-section">
 
 				<h3 class="title-sub">Past Exhibits</h3>
 
-			<?php while ( $past_query->have_posts() ) : $past_query->the_post(); // Loop for events.
+			<?php
+			while ( $past_query->have_posts() ) :
+				$past_query->the_post(); // Loop for events.
 
 				get_template_part( 'inc/exhibits-detail' );
 
 				wp_reset_postdata(); // Restore global post data stomped by the_post().
 
-			endwhile; // End of the loop. ?>
+			endwhile; // End of the loop.
+			?>
 
 			</div>
 			<!-- END OF UPCOMING EXHIBITS LOOP -->

--- a/page-exhibits-rotch-library.php
+++ b/page-exhibits-rotch-library.php
@@ -20,24 +20,25 @@ get_header( 'child' );
 			<div class="main-content">
 
 			<?php
+
 			$current_query = new WP_Query(
 				array(
-					'post_type'   => 'exhibits',  // Only query exhibits.
-					'posts_per_page' => 10,
+					'post_type'           => 'exhibits',  // Only query exhibits.
+					'posts_per_page'      => 10,
 					'ignore_sticky_posts' => false,
-					'meta_key'		=> 'start_date',
-					'orderby'     => 'start_date',
-					'order'       => 'DESC',      // Descending, so later events first.
-					'meta_query'  => array(
+					'meta_key'            => 'start_date',
+					'orderby'             => 'start_date',
+					'order'               => 'DESC',      // Descending, so later events first.
+					'meta_query'          => array(
 						array(
 							'key'     => 'start_date',     // Which meta to query.
-							'value'   => date( 'Y-m-d' ),  // Value for comparison.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 							'compare' => '<=',             // Method of comparison.
 							'type'    => 'DATE',
 						),
 						array(
 							'key'     => 'end_date',       // Which meta to query.
-							'value'   => date( 'Y-m-d' ),  // Value for comparison.
+							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 							'compare' => '>=',             // Method of comparison.
 							'type'    => 'DATE',
 						),
@@ -56,8 +57,10 @@ get_header( 'child' );
 
 				<h3 class="title-sub">Current Exhibits</h3>
 
-				<?php if ( $current_query->have_posts() ) :
-					while ( $current_query->have_posts() ) : $current_query->the_post(); // Loop for current exhibits.
+				<?php
+				if ( $current_query->have_posts() ) :
+					while ( $current_query->have_posts() ) :
+						$current_query->the_post(); // Loop for current exhibits.
 
 						get_template_part( 'inc/exhibits-detail' );
 
@@ -65,7 +68,8 @@ get_header( 'child' );
 
 						wp_reset_postdata();
 
-				else : ?>
+				else :
+					?>
 
 					<p><?php esc_html_e( 'There are no current exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
 
@@ -76,18 +80,18 @@ get_header( 'child' );
 		<!-- END OF CURRENT EXHIBITS LOOP -->
 
 		<?php
-		$paged = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
+
 		$future_query = new WP_Query(
 			array(
-				'post_type'   => 'exhibits',  // Only query exhibits.
-				'meta_key'		=> 'start_date',
+				'post_type'      => 'exhibits',  // Only query exhibits.
+				'meta_key'       => 'start_date',
 				'posts_per_page' => 10,
-				'orderby'    => 'start_date',
-				'order'       => 'ASC',        // Descending, so later events first.
-				'meta_query'  => array(
+				'orderby'        => 'start_date',
+				'order'          => 'ASC',        // Descending, so later events first.
+				'meta_query'     => array(
 					array(
 						'key'     => 'start_date',     // Which meta to query.
-						'value'   => date( 'Y-m-d' ),  // Value for comparison.
+						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 						'compare' => '>',             // Method of comparison.
 						'type'    => 'DATE',
 					),
@@ -96,18 +100,20 @@ get_header( 'child' );
 						'value'   => 'Rotch Library',  // Value for comparison.
 						'compare' => '=',             // Method of comparison.
 						'type'    => 'CHAR',
-				), // The meta_query is an array of query items.
+					), // The meta_query is an array of query items.
 				), // End meta_query array.
 			) // End array.
 		); // Close WP_Query constructor call.
-		?> 
+		?>
 
 			<div class="exhibits-feed-section">
 
 				<h3 class="title-sub">Upcoming Exhibits</h3>
 
-				<?php if ( $future_query->have_posts() ) :
-					while ( $future_query->have_posts() ) : $future_query->the_post(); // Loop for future exhibits.
+				<?php
+				if ( $future_query->have_posts() ) :
+					while ( $future_query->have_posts() ) :
+						$future_query->the_post(); // Loop for future exhibits.
 
 						get_template_part( 'inc/exhibits-detail' );
 
@@ -115,7 +121,8 @@ get_header( 'child' );
 
 					wp_reset_postdata();
 
-				else : ?>
+				else :
+					?>
 
 					<p><?php esc_html_e( 'There are no upcoming exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
 
@@ -129,15 +136,15 @@ get_header( 'child' );
 
 		$past_query = new WP_Query(
 			array(
-				'post_type'   => 'exhibits',  // Only query exhibits.
-				'meta_key'		=> 'end_date',
+				'post_type'      => 'exhibits',  // Only query exhibits.
+				'meta_key'       => 'end_date',
 				'posts_per_page' => 5,
-				'orderby'    => 'end_date',
-				'order'       => 'DESC',      // Descending, so later events first.
-				'meta_query'  => array(
+				'orderby'        => 'end_date',
+				'order'          => 'DESC',      // Descending, so later events first.
+				'meta_query'     => array(
 					array(
 						'key'     => 'end_date',       // Which meta to query.
-						'value'   => date( 'Y-m-d' ),  // Value for comparison.
+						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
 						'compare' => '<',              // Method of comparison.
 						'type'    => 'DATE',
 					),
@@ -146,24 +153,27 @@ get_header( 'child' );
 						'value'   => 'Rotch Library',  // Value for comparison.
 						'compare' => '=',             // Method of comparison.
 						'type'    => 'CHAR',
-					),// The meta_query is an array of query items.
+					), // The meta_query is an array of query items.
 				), // End meta_query array.
 			) // End array.
 		); // Close WP_Query constructor call.
 
-		?> 
+		?>
 
 			<div class="exhibits-feed-section">
 
 				<h3 class="title-sub">Past Exhibits</h3>
 
-			<?php while ( $past_query->have_posts() ) : $past_query->the_post(); // Loop for events.
+			<?php
+			while ( $past_query->have_posts() ) :
+				$past_query->the_post(); // Loop for events.
 
 				get_template_part( 'inc/exhibits-detail' );
 
 				wp_reset_postdata(); // Restore global post data stomped by the_post().
 
-			endwhile; // End of the loop. ?>
+			endwhile; // End of the loop.
+			?>
 
 			</div>
 			<!-- END OF UPCOMING EXHIBITS LOOP -->

--- a/single-exhibits.php
+++ b/single-exhibits.php
@@ -11,6 +11,7 @@ get_header( 'child' );
 
 get_template_part( 'inc/breadcrumbs', 'child' );
 
+$location_info = get_exhibit_location();
 ?>
 
 <div id="stage" class="inner" role="main">
@@ -28,7 +29,7 @@ get_template_part( 'inc/breadcrumbs', 'child' );
 
 				<div class="article-head">
 				
-						<p class="title-sub"><?php the_field( 'location' ); ?> Exhibit</p>
+						<p class="title-sub"><?php echo esc_html( $location_info['name'] ); ?> Exhibit</p>
 				
 
 					<h2><?php the_title(); ?></h2>

--- a/single-exhibits.php
+++ b/single-exhibits.php
@@ -21,25 +21,28 @@ get_template_part( 'inc/breadcrumbs', 'child' );
 
 		<div class="content-main main-content">
 
-			<?php while ( have_posts() ) : the_post(); ?>
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				?>
 
 				<div class="article-head">
 				
-						<p class="title-sub"><?php the_field( 'location' ) ?> Exhibit</p>
+						<p class="title-sub"><?php the_field( 'location' ); ?> Exhibit</p>
 				
 
 					<h2><?php the_title(); ?></h2>
 					<?php if ( get_field( 'subtitle' ) ) : ?>
-						<h3 class="sub-title"><?php the_field( 'subtitle' );?></h3>
+						<h3 class="sub-title"><?php the_field( 'subtitle' ); ?></h3>
 					<?php endif; ?>
 
 					<p class="date-span">
-						<?php the_field( 'start_date' );?> 
+						<?php the_field( 'start_date' ); ?>
 						- 
-						<?php the_field( 'end_date' );?>
+						<?php the_field( 'end_date' ); ?>
 					</p>
 					<?php if ( get_field( 'sponsored' ) ) : ?>
-						<p class="sponsored-content"><?php the_field( 'sponsored' );?></p>
+						<p class="sponsored-content"><?php the_field( 'sponsored' ); ?></p>
 					<?php endif; ?>
 
 				</div>


### PR DESCRIPTION
#### Why are these changes being introduced:

* The Libraries are starting to place exhibits into locations which were not anticipated during the initial development of this theme (which supplies page templates that are hard-coded only to two locations: the Maihaugen Gallery or the Rotch Library). Rather than copy-pasting these templates to result in more bespoke code, this should be abstracted to something more sustainable.
* The way that location information is defined in custom fields is likewise tightly bound to these two locations, making the introduction of new locations a step that requires developer attention.
* Some Exhibits are also anticipated with no firm end date, but our current page templates do not support data of this type.
* All the templates which provide the current behavior have some technical debt that is flagged by our linter.

#### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/uxws-1396

#### How does this address that need:

This PR does several things in order:

1. Any file that is edited during this work is cleaned of legacy problems as flagged by PHPCS. This should result in our linter having no issues with the affected lines (or at least to make any issues more easily reviewable as exceptions).
2. Introduces a new `Exhibits | Location Index` page template, derived from the existing Maihaugen and Rotch templates. Instead of having a hard-coded location value, however, it loads the targeted location from the post's Category assignments.
3. The new template, as well as one legacy template which loads all exhibits across locations, are updated to anticipate that the end date for Exhibits is now optional.
4. A small bit of code cleanup for the "show all exhibits" template, which somehow wasn't flagged before step 3.
5. A new helper function is added to `functions.php`, allowing page templates to look up location information according to the new data model. The need for this helper function is driven by the fact that some exhibits will be placed in a catchall category, with the actual name of the location stored in a separate field. Additionally, some exhibits may be placed into multiple locations. Navigating all these conditionals seems like something for a helper function, rather than repeated logic across multiple page templates.
 
#### Document any side effects to this change:

* The helper function is a bit longer than our linter prefers.
* The helper function returning an array of values is a bit different from how WordPress normally operates, where `get_the_*` functions typically return strings rather than arrays. Given how related the return values are, however, and the need to have a single returned entity, I hope this is acceptable.
* The choice to use page templates for this feature, rather than leveraging category pages, is a judgement call. Hopefully future-us won't end up cursing this decision.
* A future PR will remove the legacy page templates entirely, but we can't make that change until the pages currently on those templates have been moved.

#### How can a reviewer manually see the effects of these changes?

This branch has been deployed to the staging server.

#### Todo:
- [ ] Documentation
- [ ] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?

YES - there's a coordinated PR for the Custom Child Post Types plugin, which has also been deployed.
MITLibraries/Custom-Child-Theme-Post-Types#5

#### Requires change to deploy process?

NO
