### PR TITLE
Remove link and relative positioning from location names

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1109,8 +1109,6 @@ a.px14 {
 	font-weight: 600;
 	margin-left: 65px;
 	font-size: 16px;
-	position: relative;
-	top: 5px;
 }
 
 .category-image {

--- a/functions.php
+++ b/functions.php
@@ -389,13 +389,11 @@ function get_exhibit_location() {
 			$location_name = get_field( 'uncategorized_location' );
 		}
 	}
-	$location_link    = site_url() . '/' . $locations_rebuild[0]['slug'];
 	$location_initial = substr( $location_name, 0, 1 );
 
 	// 4. Return those calculated values in an array.
 	return array(
 		'name'    => $location_name,
-		'link'    => $location_link,
 		'initial' => $location_initial,
 	);
 }

--- a/inc/exhibits-detail.php
+++ b/inc/exhibits-detail.php
@@ -10,10 +10,11 @@
 
 $location_info = get_exhibit_location();
 ?>
+
 <div class="exhibits-feed">
 	<div class="entry-categories">
 		<div class="entry-cats-list">
-			<a href="<?php echo esc_url( $location_info['link'] ); ?>"><span class="category-bg"><span class="category-init"><?php echo esc_html( $location_info['initial'] ); ?></span></span><span class="cat-name"><?php echo esc_html( $location_info['name'] ); ?> Exhibit</span></a>
+			<span class="category-bg"><span class="category-init"><?php echo esc_html( $location_info['initial'] ); ?></span></span><span class="cat-name"><?php echo esc_html( $location_info['name'] ); ?> Exhibit</span>
 		</div>
 	</div>
 	<div class="category-post">


### PR DESCRIPTION
** Why are these changes being introduced:

* Chrome on Mac is interpreting a relatively positioned text element differently from other browsers, which results in incorrect displays for some users.
* These location names are currently links to the index page for that location, but building that link for the "other locations" page is proving difficult.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/uxws-1399

** How does this address that need:

* This removes the relative positioning that is applied to location names on Exhibit cards. While this means that location names will be rendered slightly higher (by five pixels), this shift means that all browsers should now place the location name consistently with regards to the link underlining.
* The link itself is also being removed, to avoid the incorrect link being used for uncategorized exhibits.

** Document any side effects to this change:

* The location names on an Exhibit card will appear slightly farther away from the exhibit box.

## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
A few sentences describing the overall goals of the pull request's commits.
Why are we making these changes? Is there more work to be done to fully
achieve these goals?

#### Helpful background context (if appropriate)

#### How can a reviewer manually see the effects of these changes?

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/UXWS-1399

#### Screenshots (if appropriate)

#### Todo:
- [x] Documentation
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
